### PR TITLE
Add expressions and constants to model definition (globally)

### DIFF
--- a/conf/models/segmentation.yaml
+++ b/conf/models/segmentation.yaml
@@ -39,7 +39,7 @@ models:
             nn: [131, 128]
         up_conv:
             module_name: FPModule
-            up_conv_nn: [[256, 128], [160, 64], [64 + FEAT, 64]]
+            up_conv_nn: [[128 + 128, 128], [128 + 32, 64], [64 + FEAT, 64]]
             up_k: [1, 1, 1]
             skip: True
         mlp_cls:
@@ -61,7 +61,7 @@ models:
             nn: [131, 128]
         up_conv:
             module_name: FPModule
-            up_conv_nn: [[256, 128], [160, 64], [80, 64], [64 + FEAT, 64]] 
+            up_conv_nn: [[128 + 128, 128], [128 + 32, 64], [64 + 16, 64], [64 + FEAT, 64]] 
             up_k: [1, 1, 1, 1]
             skip: True
         mlp_cls:
@@ -106,7 +106,7 @@ models:
             nn: [131, 128] #[3  + 128]
         up_conv:
             module_name: FPModule
-            up_conv_nn: [[256, 128], [192, 64], [96, 32], [48, 32], [32, 64]]
+            up_conv_nn: [[128 + 128, 128], [128 + 64, 64], [64 + 32, 32], [32 + 16, 32], [32, 64]]
             up_k: [1, 3, 3, 3, 3]
             skip: True
         mlp_cls:
@@ -123,7 +123,7 @@ models:
             down_conv_nn: [[FEAT, 32], [32, 64]]
         up_conv:
             module_name: FPModule
-            up_conv_nn: [[192, 64], [96, 64], [64 + FEAT, 64]]     
+            up_conv_nn: [[128 + 64, 64], [64 + 32, 64], [64 + FEAT, 64]]     
             up_k: [1, 3, 3]   
             skip: True    
         innermost:
@@ -145,12 +145,12 @@ models:
             module_name: ResidualUpsampleBKPConv
             radius: [1, 0.2, 0.1]
             up_conv_nn: [[128, 128], [64, 64], [64, 64]]     
-            mlp_nn: [[192, 64], [96, 64], [64 + FEAT, 64]] 
+            mlp_nn: [[128 + 64, 64], [32 + 64, 64], [64 + FEAT, 64]] 
             skip: True    
         innermost:
             module_name: GlobalBaseModule
             aggr: max
-            nn: [67, 128]
+            nn: [64 + FEAT, 128]
         mlp_cls: 
             nn: [64, 64, 64, 64, 64]
             dropout: 0.5
@@ -166,7 +166,7 @@ models:
             module_name: SimpleUpsampleKPConv
             radius: [1, 0.2, 0.1]
             up_conv_nn: [[128, 128], [64, 64], [64, 64]]     
-            mlp_nn: [[192, 64], [96, 64], [64 + FEAT, 64]] 
+            mlp_nn: [[128 + 64, 64], [64 + 32, 64], [64 + FEAT, 64]] 
             skip: True    
         innermost:
             module_name: GlobalBaseModule
@@ -188,7 +188,7 @@ models:
             module_name: FPModule
             ratios: [1, 0.25, 0.2]
             radius: [1, 0.2, 0.1]
-            up_conv_nn: [[1280, 256, 256], [384, 256, 128], [128 + FEAT, 128, 128, 128]]
+            up_conv_nn: [[1280, 256, 256], [256 + 128, 256, 128], [128 + FEAT, 128, 128, 128]]
             up_k: [1, 3, 3]   
             skip: True    
         innermost:

--- a/conf/models/segmentation.yaml
+++ b/conf/models/segmentation.yaml
@@ -80,12 +80,12 @@ models:
         innermost:
             module_name: GlobalBaseModule
             aggr: max
-            nn: [131, 128] #[3  + 128]
+            nn: [128 + FEAT, 128] 
         up_conv:
             module_name: FPModule
             ratios: [1, 0.25, 0.2]
             radius: [0.2, 0.2, 0.1]
-            up_conv_nn: [[256, 64], [128, 64], [64 + FEAT, 64]]
+            up_conv_nn: [[128 + 128, 64], [64 + 64, 64], [64, 64]]
             up_k: [1, 3, 3]
             skip: True
         mlp_cls:

--- a/models/KPConv/modules.py
+++ b/models/KPConv/modules.py
@@ -56,8 +56,6 @@ class LightDeformableKPConv(BaseConvolutionDown):
     def __init__(self, ratio=None, radius=None, down_conv_nn=None, num_points=16, nb_feature=0, *args, **kwargs):
         super(LightDeformableKPConv, self).__init__(FPSSampler(ratio), RadiusNeighbourFinder(radius), *args, **kwargs)
 
-        down_conv_nn = utils.resolve_mlp_list(down_conv_nn, FEAT=nb_feature)
-
         self.ratio = ratio
         self.radius = radius
 
@@ -79,8 +77,6 @@ class KPConv(BaseConvolutionDown):
     def __init__(self, ratio=None, radius=None, down_conv_nn=None, num_points=16,  nb_feature=0,  *args, **kwargs):
         super(KPConv, self).__init__(FPSSampler(ratio), RadiusNeighbourFinder(radius), *args, **kwargs)
 
-        down_conv_nn = utils.resolve_mlp_list(down_conv_nn, FEAT=nb_feature)
-
         self.ratio = ratio
         self.radius = radius
 
@@ -101,7 +97,6 @@ class ResidualBKPConv(BaseConvolutionDown):
     def __init__(self, ratio=None, radius=None, down_conv_nn=None, num_points=16, nb_feature=0, *args, **kwargs):
         super(ResidualBKPConv, self).__init__(FPSSampler(ratio), RadiusNeighbourFinder(radius), *args, **kwargs)
 
-        down_conv_nn = utils.resolve_mlp_list(down_conv_nn, FEAT=nb_feature)
         self.ratio = ratio
         self.radius = radius
         self.max_num_neighbors = kwargs.get("max_num_neighbors", 64)
@@ -138,9 +133,6 @@ class SimpleUpsampleKPConv(BaseConvolutionUp):
     def __init__(self, ratio=None, radius=None, up_conv_nn=None, mlp_nn=None, num_points=16, nb_feature=0, *args, **kwargs):
         super(SimpleUpsampleKPConv, self).__init__(RadiusNeighbourFinder(radius), *args, **kwargs)
 
-        up_conv_nn = utils.resolve_mlp_list(up_conv_nn, FEAT=nb_feature)
-        mlp_nn = utils.resolve_mlp_list(mlp_nn, FEAT=nb_feature)
-
         in_features, out_features = up_conv_nn
 
         # KPCONV arguments
@@ -160,9 +152,6 @@ class SimpleUpsampleKPConv(BaseConvolutionUp):
 class ResidualUpsampleBKPConv(BaseConvolutionUp):
     def __init__(self, ratio=None, radius=None, up_conv_nn=None, mlp_nn=None, num_points=16, nb_feature=0, *args, **kwargs):
         super(ResidualUpsampleBKPConv, self).__init__(RadiusNeighbourFinder(radius))
-
-        up_conv_nn = utils.resolve_mlp_list(up_conv_nn, FEAT=nb_feature)
-        mlp_nn = utils.resolve_mlp_list(mlp_nn, FEAT=nb_feature)
 
         self.ratio = ratio
         self.radius = radius

--- a/models/RSConv/modules.py
+++ b/models/RSConv/modules.py
@@ -58,9 +58,9 @@ class RSConv(BaseConvolutionDown):
     def __init__(self, ratio=None, radius=None, local_nn=None, down_conv_nn=None, nb_feature=None, *args, **kwargs):
         super(RSConv, self).__init__(FPSSampler(ratio), RadiusNeighbourFinder(radius), *args, **kwargs)
 
-        local_nn = utils.resolve_mlp_list(local_nn, FEAT = nb_feature)
+        # local_nn = utils.resolve_mlp_list(local_nn, FEAT = nb_feature)
 
-        down_conv_nn = utils.resolve_mlp_list(down_conv_nn, FEAT = nb_feature)
+        # down_conv_nn = utils.resolve_mlp_list(down_conv_nn, FEAT = nb_feature)
         
         self._conv = Convolution(local_nn=local_nn, global_nn=down_conv_nn)
 

--- a/models/RSConv/modules.py
+++ b/models/RSConv/modules.py
@@ -57,10 +57,6 @@ class Convolution(MessagePassing):
 class RSConv(BaseConvolutionDown):
     def __init__(self, ratio=None, radius=None, local_nn=None, down_conv_nn=None, nb_feature=None, *args, **kwargs):
         super(RSConv, self).__init__(FPSSampler(ratio), RadiusNeighbourFinder(radius), *args, **kwargs)
-
-        # local_nn = utils.resolve_mlp_list(local_nn, FEAT = nb_feature)
-
-        # down_conv_nn = utils.resolve_mlp_list(down_conv_nn, FEAT = nb_feature)
         
         self._conv = Convolution(local_nn=local_nn, global_nn=down_conv_nn)
 

--- a/models/core_modules.py
+++ b/models/core_modules.py
@@ -134,8 +134,7 @@ class FPModule(BaseConvolutionUp):
 
     def __init__(self, up_k, up_conv_nn, nb_feature=None, **kwargs):
         super(FPModule, self).__init__(None)
-        # if kwargs.get('index') == 0 and nb_feature is not None:
-            # up_conv_nn = utils.resolve_mlp_list(up_conv_nn, FEAT = nb_feature)
+
         self.k = up_k
         self.nn = MLP(up_conv_nn)
 

--- a/models/core_modules.py
+++ b/models/core_modules.py
@@ -134,8 +134,8 @@ class FPModule(BaseConvolutionUp):
 
     def __init__(self, up_k, up_conv_nn, nb_feature=None, **kwargs):
         super(FPModule, self).__init__(None)
-        if kwargs.get('index') == 0 and nb_feature is not None:
-            up_conv_nn = utils.resolve_mlp_list(up_conv_nn, FEAT = nb_feature)
+        # if kwargs.get('index') == 0 and nb_feature is not None:
+            # up_conv_nn = utils.resolve_mlp_list(up_conv_nn, FEAT = nb_feature)
         self.k = up_k
         self.nn = MLP(up_conv_nn)
 

--- a/models/model_building_utils/model_definition_resolver.py
+++ b/models/model_building_utils/model_definition_resolver.py
@@ -1,0 +1,48 @@
+
+from omegaconf.dictconfig import DictConfig 
+from omegaconf.listconfig import ListConfig
+
+def resolve_model(model_config, dataset, tested_task):
+
+    #placeholders to subsitute 
+    constants = {
+        'FEAT': dataset.feature_dimension, 
+        'TASK': tested_task
+    }
+
+    #user defined contants to subsitute 
+    if 'define_constants' in model_config.keys():
+        constants.update(dict(model_config.define_constants))
+
+    _resolve(model_config, constants)
+
+#Resolves expressions and constants in obj. 
+#returns False if obj is a ListConfig or DictConfig, True is obj is a primative type.
+def _resolve(obj, constants):
+
+    if type(obj) == DictConfig:
+        it = (k for k in obj)
+    elif type(obj) == ListConfig:
+        it = range(len(obj))
+    else: 
+        #obj is a single element
+        return True
+
+    #recursively resolve all children of obj
+    for k in it:
+
+        #if obj[k] is a primative type, evalulate it
+        if _resolve(obj[k], constants):
+            if type(obj[k]) is str:
+                try: 
+                    obj[k] = eval(obj[k], constants)
+                except NameError: 
+                    #we tried to resolve a string which isn't an expression
+                    pass
+                except ValueError:
+                    #we tried to resolve a string which is also a builtin (e.g. max)
+                    pass 
+    
+    return False
+
+

--- a/models/utils.py
+++ b/models/utils.py
@@ -25,10 +25,10 @@ def find_model_using_name(model_type, task, option, dataset: BaseDataset) -> Bas
     modules_lib = importlib.import_module(module_filename)
     return model(option, model_type, dataset, modules_lib)
 
-def resolve_mlp_list(mlp, **kwargs):
+# def resolve_mlp_list(mlp, **kwargs):
 
-    for ind, x in enumerate(mlp):
-        if type(x) == str:
-            mlp[ind] = eval(x, kwargs)
+#     for ind, x in enumerate(mlp):
+#         if type(x) == str:
+#             mlp[ind] = eval(x, kwargs)
 
-    return mlp 
+#     return mlp 

--- a/models/utils.py
+++ b/models/utils.py
@@ -24,11 +24,3 @@ def find_model_using_name(model_type, task, option, dataset: BaseDataset) -> Bas
     module_filename = '.'.join(["models", model_type, "modules"])
     modules_lib = importlib.import_module(module_filename)
     return model(option, model_type, dataset, modules_lib)
-
-# def resolve_mlp_list(mlp, **kwargs):
-
-#     for ind, x in enumerate(mlp):
-#         if type(x) == str:
-#             mlp[ind] = eval(x, kwargs)
-
-#     return mlp 

--- a/test/test_config/test_resolver_in.yaml
+++ b/test/test_config/test_resolver_in.yaml
@@ -1,0 +1,18 @@
+type: mytype
+define_constants:
+    L1_OUT: 20
+    MODULE: RSConv
+down_conv:
+    module_name: MODULE
+    aggr: max
+    number: 5
+    expression: 5 + 5
+    variable: FEAT
+    variable_expression: FEAT + 5
+    number_nn: [8, 16]
+    nn: [FEAT, FEAT * 2, 16 + 16, L1_OUT * 2, L1_OUT]
+    nested_nn: [[16*2, 8], [FEAT, FEAT*2]]
+    nested_nested_nn: [[[8+8, 16], [16, 16//2]], [[8, 4], [4, FEAT]]]
+    nested_dict:
+        number: 3
+        nn: [FEAT, 16 + 8]

--- a/test/test_config/test_resolver_out.yaml
+++ b/test/test_config/test_resolver_out.yaml
@@ -1,0 +1,18 @@
+type: mytype
+define_constants:
+    L1_OUT: 20
+    MODULE: RSConv
+down_conv:
+    module_name: RSConv
+    aggr: max
+    number: 5
+    expression: 10
+    variable: 6
+    variable_expression: 11
+    number_nn: [8, 16]
+    nn: [6, 12, 32, 40, 20]
+    nested_nn: [[32, 8], [6, 12]]
+    nested_nested_nn: [[[16, 16], [16, 8]], [[8, 4], [4, 6]]]
+    nested_dict:
+        number: 3
+        nn: [6, 24]

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -9,7 +9,12 @@ sys.path.append(ROOT)
 
 from models.utils import find_model_using_name
 from models.pointnet2.nn import SegmentationModel
+from models.model_building_utils.model_definition_resolver import resolve_model
 
+#calls resolve_model, then find_model_using_name
+def _find_model_using_name(model_type, task, model_config, dataset):
+    resolve_model(model_config, dataset, task)
+    return find_model_using_name(model_type, task, model_config, dataset)
 
 class MockDataset(torch.utils.data.Dataset):
     def __init__(self, feature_size=0):
@@ -43,13 +48,13 @@ class TestModelUtils(unittest.TestCase):
             print(model_name)
             if model_name not in ["MyTemplateModel", "Randlanet_Res", "Randlanet_Conv"]:
                 params = self.config['models'][model_name]
-                find_model_using_name(params.type, 'segmentation', params, MockDataset(6))
+                _find_model_using_name(params.type, 'segmentation', params, MockDataset(6))
 
     def test_pointnet2(self):
         model_type = 'pointnet2'
         params = self.config['models'][model_type]
         dataset = MockDataset(5)
-        model = find_model_using_name(model_type, 'segmentation', params, dataset)
+        model = _find_model_using_name(model_type, 'segmentation', params, dataset)
         model.set_input(dataset[0])
         model.forward()
 
@@ -57,7 +62,7 @@ class TestModelUtils(unittest.TestCase):
         model_type = 'KPConv'
         params = self.config['models']['SimpleKPConv']
         dataset = MockDataset(5)
-        model = find_model_using_name(model_type, 'segmentation', params, dataset)
+        model = _find_model_using_name(model_type, 'segmentation', params, dataset)
         model.set_input(dataset[0])
         model.forward()
 

--- a/test/test_resolver.py
+++ b/test/test_resolver.py
@@ -2,6 +2,7 @@ import unittest
 
 from omegaconf import OmegaConf
 import torch 
+from torch_geometric.data import Data, Batch
 import os
 import sys
 ROOT = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')

--- a/test/test_resolver.py
+++ b/test/test_resolver.py
@@ -1,0 +1,50 @@
+import unittest
+
+from omegaconf import OmegaConf
+import torch 
+import os
+import sys
+ROOT = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')
+sys.path.append(ROOT)
+
+from models.model_building_utils.model_definition_resolver import resolve_model
+
+
+
+class MockDataset(torch.utils.data.Dataset):
+    def __init__(self, feature_size=6):
+        self.feature_dimension = feature_size
+        self.num_classes = 10
+        self.weight_classes = None
+        nb_points = 100
+        self._pos = torch.randn((nb_points, 3))
+        if feature_size > 0:
+            self._feature = torch.tensor([range(feature_size) for i in range(self._pos.shape[0])], dtype=torch.float)
+        else:
+            self._feature = None
+        self._y = torch.tensor([range(10) for i in range(self._pos.shape[0])], dtype=torch.float)
+        self._batch = torch.tensor([0 for i in range(self._pos.shape[0])])
+
+    def __getitem__(self, index):
+        return Batch(pos=self._pos, x=self._feature,
+                     y=self._y, batch=self._batch)
+
+class TestModelDefinitionResolver(unittest.TestCase):
+
+    def test_resolve_1(self):
+        model_conf = os.path.join(ROOT, 'test/test_config/test_resolver_in.yaml')
+        config = OmegaConf.load(model_conf)
+        dataset = MockDataset(6)
+        tested_task = 'segmentation'
+
+        resolve_model(config, dataset, tested_task)
+
+        expected = OmegaConf.load(
+            os.path.join(ROOT, 'test/test_config/test_resolver_out.yaml')
+        )
+
+        self.assertEqual(dict(config), dict(expected))
+
+
+if __name__ == '__main__':
+    unittest.main() 

--- a/train.py
+++ b/train.py
@@ -13,6 +13,7 @@ import wandb
 from omegaconf import OmegaConf
 
 from models.utils import find_model_using_name
+from models.model_building_utils.model_definition_resolver import resolve_model
 from models.base_model import BaseModel
 from metrics.metrics_tracker import get_tracker, BaseTracker
 from metrics.colored_tqdm import Coloredtqdm as Ctq, COLORS
@@ -85,6 +86,7 @@ def main(cfg):
     # Find and create associated model
     model_config = getattr(cfg.models, tested_model_name, None)
     model_config = OmegaConf.merge(model_config, cfg.training)
+    resolve_model(model_config, dataset, tested_task)
     model = find_model_using_name(model_config.type, tested_task, model_config, dataset)
     model.set_optimizer(getattr(torch.optim, cfg.training.optimizer, None), lr=cfg.training.lr)
 


### PR DESCRIPTION
Solves #46 

This lets users put things like `inDim: FEAT` or `nn:[FEAT*2, 16 + 16]` in the model definition. Previously these expressions had to be evaluated per argument within the convolutions. Now it is done for the entire model config before calling `find_model_using_name`