### PR TITLE
ABC for modules with internal losses

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,6 +1,6 @@
 # Those arguments within experiment defines which model, dataset and task to be created for benchmarking
 experiment:
-    name: pointnet2
+    name: DeformableResidualKPConv
     experiment_name: "" # Wether to use hydra naming convention for the experiment
     log_dir: "" # Wether to use hydra automatic path generation for saving training
     resume: True

--- a/datasets/shapenet_dataset.py
+++ b/datasets/shapenet_dataset.py
@@ -197,9 +197,9 @@ class ShapeNetDataset(BaseDataset):
         self._category = dataset_opt.category
         pre_transform = T.NormalizeScale()
         transform = T.FixedPoints(dataset_opt.num_points)
-        train_dataset = ShapeNet(self._data_path, self._category, normal=dataset_opt.normal, split='trainval',
+        train_dataset = ShapeNet(self._data_path, self._category, include_normals=dataset_opt.normal, split='trainval',
                                  pre_transform=pre_transform, transform=transform)
-        test_dataset = ShapeNet(self._data_path, self._category, normal=dataset_opt.normal, split='test',
+        test_dataset = ShapeNet(self._data_path, self._category, include_normals=dataset_opt.normal, split='test',
                                 pre_transform=pre_transform, transform=transform)
 
         self._create_dataloaders(train_dataset, test_dataset, validation=None)

--- a/models/KPConv/kernels.py
+++ b/models/KPConv/kernels.py
@@ -8,6 +8,7 @@ import math
 from torch.nn.parameter import Parameter
 from .kernel_utils import kernel_point_optimization_debug
 from torch_geometric.nn import MessagePassing
+from models.core_modules import BaseInternalLossModule
 
 def KPconv_op(self, x_j, pos_i, pos_j):
     if x_j is None:
@@ -128,7 +129,7 @@ def permissive_loss(deformed_kpoints, radius):
 
 # Implements the Light Deformable KPConv
 #https://github.com/HuguesTHOMAS/KPConv/blob/master/kernels/convolution_ops.py#L503
-class LightDeformablePointKernel(MessagePassing):
+class LightDeformablePointKernel(MessagePassing, BaseInternalLossModule):
 
     '''
     Implements KPConv: Flexible and Deformable Convolution for Point Clouds from 
@@ -254,6 +255,9 @@ class LightDeformablePointKernel(MessagePassing):
         out_features = torch.einsum("na, nac -> nc", weighted_features, K_weights)
         
         return out_features
+
+    def get_internal_losses(self):
+        return self.internal_losses
 
     def update(self, aggr_out, pos):
         return aggr_out

--- a/models/KPConv/nn.py
+++ b/models/KPConv/nn.py
@@ -50,7 +50,7 @@ class SegmentationModel(UnetBasedModel):
         # caculate the intermediate results if necessary; here self.output has been computed during function <forward>
         # calculate loss given the input and intermediate results
 
-        self.loss_seg = F.nll_loss(self.output, self.labels) + self.get_internal_losses()
+        self.loss_seg = F.nll_loss(self.output, self.labels) + self.get_internal_loss()
         if torch.isnan(self.loss_seg):
             import pdb
             pdb.set_trace()

--- a/models/core_modules.py
+++ b/models/core_modules.py
@@ -1,13 +1,13 @@
 from abc import ABC, abstractmethod
 import math
 from functools import partial
+from typing import Dict, Any
 import torch
 from torch import nn
 from torch.nn import Sequential as Seq, Linear as Lin, ReLU, LeakyReLU, BatchNorm1d as BN, Dropout
 from torch_geometric.nn import knn_interpolate, fps, radius, global_max_pool, global_mean_pool, knn
 from torch_geometric.data import Batch
 from torch_geometric.utils import scatter_
-import models.utils as utils
 from models.core_sampling_and_search import BaseMSNeighbourFinder
 
 
@@ -268,3 +268,12 @@ class BaseResnetBlock(ABC, torch.nn.Module):
         batch_obj.batch = data.batch
         copy_from_to(data, batch_obj)
         return batch_obj
+
+
+class BaseInternalLossModule(ABC):
+    '''ABC for modules which have internal loss(es)
+    '''
+
+    @abstractmethod
+    def get_internal_losses(self) -> Dict[str, Any]:
+        pass

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -43,12 +43,12 @@ class TestInternalLosses(unittest.TestCase):
         lossDict = self.model.get_named_internal_losses()
         self.assertEqual(lossDict, {'mock_loss_3': 1, 'mock_loss_1': 0.5, 'mock_loss_2': 0.3})
 
-    def test_get_internal_losses(self):
+    def test_get_internal_loss(self):
 
         loss = self.model.get_internal_loss()
         self.assertAlmostEqual(loss.item(), 0.6)
 
-        
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -1,0 +1,57 @@
+import unittest
+
+import torch
+
+import os
+import sys
+ROOT = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')
+sys.path.append(ROOT)
+
+from models.core_modules import BaseInternalLossModule
+from models.base_model import BaseModel
+
+class MockLossModule(torch.nn.Module, BaseInternalLossModule):
+
+    def __init__(self, internal_losses):
+        super().__init__()
+        self.internal_losses = internal_losses
+
+    def get_internal_losses(self):
+        return self.internal_losses
+
+class MockModel(BaseModel):
+
+    def __init__(self):
+        super().__init__({})
+
+        self.model1 = MockLossModule({
+            'mock_loss_1': torch.tensor(0.5),
+            'mock_loss_2': torch.tensor(0.3),
+        })
+
+        self.model2 = MockLossModule({
+            'mock_loss_3': torch.tensor(1.0),
+        })
+
+class TestInternalLosses(unittest.TestCase):
+
+    def setUp(self):
+        self.model = MockModel()
+
+    def test_get_named_internal_losses(self):
+
+        lossDict = self.model.get_named_internal_losses()
+        self.assertEqual(lossDict, {'mock_loss_3': 1, 'mock_loss_1': 0.5, 'mock_loss_2': 0.3})
+
+    def test_get_internal_losses(self):
+
+        loss = self.model.get_internal_loss()
+        self.assertAlmostEqual(loss.item(), 0.6)
+
+        
+if __name__ == '__main__':
+    unittest.main()
+
+
+
+


### PR DESCRIPTION
Modules can now indicate they have internal losses by inheriting from `BaseInternalLossModule`, and implementing the abstract method `get_internal_losses`. I think this is more intuitive for users than having an instance variable which is searched for recursively. 

The method used by `BaseModel` for collecting internal losses is still similar, except now it checks if child models inherit from `BaseInternalLossModule`. I have also added a method `get_named_internal_losses` to `BaseModel`, which returns a dict of all the internal losses in the model, which will allow users to choose the weightings between different losses when calculating the overall loss. 