### PR TITLE
Pointnet regularization loss

### DIFF
--- a/models/PointNet/modules.py
+++ b/models/PointNet/modules.py
@@ -16,7 +16,6 @@ class MiniPointNet(torch.nn.Module):
         self.global_nn = MLP(global_nn)
 
     def forward(self, x, batch):
-
         x = self.local_nn(x)
         x = global_max_pool(x, batch)
         x = self.global_nn(x)
@@ -38,7 +37,7 @@ class PointNetSTN3D(BaseLinearTransformSTNkD):
         return super().forward(x, x, batch)
 
 
-class PointNetSTNkD(BaseLinearTransformSTNkD):
+class PointNetSTNkD(BaseLinearTransformSTNkD, BaseInternalLossModule):
 
     def __init__(self, k=64, local_nn=[64, 64, 128, 1024], global_nn=[1024, 512, 256], batch_size=1):
         super().__init__(
@@ -50,6 +49,12 @@ class PointNetSTNkD(BaseLinearTransformSTNkD):
 
     def forward(self, x, batch):
         return super().forward(x, x, batch)
+
+    def get_internal_losses(self):
+        return {
+            'orthogonal_regularization_loss': 
+            self.get_orthogonal_regularization_loss()
+        }
 
 
 class PointNetSeg(torch.nn.Module):

--- a/models/PointNet/modules.py
+++ b/models/PointNet/modules.py
@@ -5,6 +5,7 @@ from torch_geometric.nn import global_max_pool
 
 from models.core_modules import *
 from models.core_transforms import BaseLinearTransformSTNkD
+from models.base_model import BaseInternalLossModule
 
 
 class MiniPointNet(torch.nn.Module):

--- a/models/PointNet/nn.py
+++ b/models/PointNet/nn.py
@@ -34,5 +34,6 @@ class SegmentationModel(BaseModel):
         return self.output
 
     def backward(self):
-        self.loss = F.nll_loss(self.output, self.labels)
+        internal_loss = self.get_internal_loss()
+        self.loss = F.nll_loss(self.output, self.labels) + (internal_loss if internal_loss.item() != 0 else 0) * 0.01
         self.loss.backward()

--- a/models/PointNet/nn.py
+++ b/models/PointNet/nn.py
@@ -35,5 +35,5 @@ class SegmentationModel(BaseModel):
 
     def backward(self):
         internal_loss = self.get_internal_loss()
-        self.loss = F.nll_loss(self.output, self.labels) + (internal_loss if internal_loss.item() != 0 else 0) * 0.01
+        self.loss = F.nll_loss(self.output, self.labels) + (internal_loss if internal_loss.item() != 0 else 0) * 0.001
         self.loss.backward()

--- a/models/core_transforms.py
+++ b/models/core_transforms.py
@@ -31,18 +31,30 @@ class BaseLinearTransformSTNkD(torch.nn.Module):
             Learns and applies a linear transformation to trans_x based on feat_x.
             feat_x and trans_x may be the same or different. 
         '''
-
         global_feature = self.nn(feat_x, batch)
         trans = self.fc_layer(global_feature)
 
         # needed so that transform is initialized to identity 
         trans = trans + self.identity.to(feat_x.device)
         trans = trans.view(-1, self.k, self.k)
+        self.trans = trans
 
-        # import pdb; pdb.set_trace()
         # convert trans_x from (N, K) to (B, N, K) to do batched matrix multiplication
         # batch_x = trans_x.view(self.batch_size, -1, trans_x.shape[1])
         batch_x = trans_x.view(trans_x.shape[0], 1, trans_x.shape[1])
         x_transformed = torch.bmm(batch_x, trans[batch])
 
         return x_transformed.view(len(trans_x), trans_x.shape[1])
+
+    def get_orthogonal_regularization_loss(self):
+        loss = torch.mean(
+            torch.norm(
+                torch.bmm(
+                    self.trans, self.trans.transpose(2, 1)
+                )
+                - self.identity.to(self.trans.device).view(-1, self.k, self.k),
+                dim = (1, 2)
+            )
+        )
+
+        return loss


### PR DESCRIPTION
Add a regularization loss to the linear transform STN used by pointnet to make the transform close to an orthogonal matrix. Pointnet does this so that the transform does not delete information. 