### PR TITLE
Give a name to all datasets

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 
 def eval_epoch(model: BaseModel, dataset, device, tracker: BaseTracker, checkpoint: ModelCheckpoint):
     tracker.reset("val")
-    loader = dataset.val_dataloader()
+    loader = dataset.val_dataloader
     with Ctq(loader) as tq_val_loader:
         for data in tq_val_loader:
             with torch.no_grad():
@@ -40,10 +40,10 @@ def eval_epoch(model: BaseModel, dataset, device, tracker: BaseTracker, checkpoi
 
 def test_epoch(model: BaseModel, dataset, device, tracker: BaseTracker, checkpoint: ModelCheckpoint):
 
-    loaders = dataset.test_dataloaders()
+    loaders = dataset.test_dataloaders
 
-    for idx, loader in enumerate(loaders):
-        stage_name = dataset.get_test_dataset_name(idx)
+    for loader in loaders:
+        stage_name = loader.dataset.name
         tracker.reset(stage_name)
         with Ctq(loader) as tq_test_loader:
             for data in tq_test_loader:

--- a/find_neighbour_dist.py
+++ b/find_neighbour_dist.py
@@ -51,18 +51,16 @@ def run(cfg, model: BaseModel, dataset: BaseDataset, device, measurement_name: s
 
     num_batches = getattr(cfg.debugging, "num_batches", np.inf)
 
-    run_epoch(model, dataset.train_dataloader(), device, num_batches)
+    run_epoch(model, dataset.train_dataloader, device, num_batches)
     measurements["train"] = extract_histogram(model.get_spatial_ops(), normalize=False)
 
     if dataset.has_val_loader:
-        run_epoch(model, dataset.val_dataloader(), device, num_batches)
+        run_epoch(model, dataset.val_dataloader, device, num_batches)
         measurements["val"] = extract_histogram(model.get_spatial_ops(), normalize=False)
 
-    for loader_idx, loader in enumerate(dataset.test_dataloaders()):
-        run_epoch(model, dataset.test_dataloaders(), device, num_batches)
-        measurements[dataset.get_test_dataset_name(loader_idx)] = extract_histogram(
-            model.get_spatial_ops(), normalize=False
-        )
+    for loader in dataset.test_dataloaders:
+        run_epoch(model, dataset.test_dataloaders, device, num_batches)
+        measurements[loader.dataset.name] = extract_histogram(model.get_spatial_ops(), normalize=False)
 
     with open(os.path.join(DIR, "measurements/{}.pickle".format(measurement_name)), "wb") as f:
         pickle.dump(measurements, f)

--- a/forward_scripts/forward.py
+++ b/forward_scripts/forward.py
@@ -37,10 +37,10 @@ def save(prefix, predicted):
 
 
 def run(model: BaseModel, dataset: BaseDataset, device, output_path):
-    loaders = dataset.test_dataloaders()
+    loaders = dataset.test_dataloaders
     predicted = {}
-    for idx, loader in enumerate(loaders):
-        dataset.get_test_dataset_name(idx)
+    for loader in loaders:
+        loader.dataset.name
         with Ctq(loader) as tq_test_loader:
             for data in tq_test_loader:
                 with torch.no_grad():

--- a/src/datasets/base_dataset.py
+++ b/src/datasets/base_dataset.py
@@ -18,6 +18,7 @@ from src.models.base_model import BaseModel
 # A logger for this file
 log = logging.getLogger(__name__)
 
+
 class BaseDataset:
     def __init__(self, dataset_opt):
         self.dataset_opt = dataset_opt
@@ -37,12 +38,12 @@ class BaseDataset:
         self.test_sampler = None
         self.val_sampler = None
 
-        self.train_dataset = None
-        self.test_dataset = None
-        self.val_dataset = None
+        self._train_dataset = None
+        self._test_dataset = None
+        self._val_dataset = None
 
         BaseDataset.set_transform(self, dataset_opt)
-    
+
     @staticmethod
     def add_transform(transform_list_to_be_added, out=[]):
         """ Add transforms to an existing list or not
@@ -64,7 +65,6 @@ class BaseDataset:
             else:
                 raise Exception("transform_list_to_be_added should be provided either within a list or a Compose")
         return out
-
 
     @staticmethod
     def remove_transform(transform_in, list_transform_class):
@@ -115,15 +115,15 @@ class BaseDataset:
 
     @staticmethod
     def _get_collate_function(conv_type, is_multiscale):
-
-        is_dense = ConvolutionFormatFactory.check_is_dense_format(conv_type)
-
         if is_multiscale:
             if conv_type.lower() == ConvolutionFormat.PARTIAL_DENSE.value.lower():
                 return lambda datalist: MultiScaleBatch.from_data_list(datalist)
             else:
-                raise NotImplementedError("MultiscaleTransform is activated and supported only for partial_dense format")
+                raise NotImplementedError(
+                    "MultiscaleTransform is activated and supported only for partial_dense format"
+                )
 
+        is_dense = ConvolutionFormatFactory.check_is_dense_format(conv_type)
         if is_dense:
             return lambda datalist: SimpleBatch.from_data_list(datalist)
         else:
@@ -131,9 +131,7 @@ class BaseDataset:
 
     @staticmethod
     def get_num_samples(batch, conv_type):
-
         is_dense = ConvolutionFormatFactory.check_is_dense_format(conv_type)
-
         if is_dense:
             return batch.pos.shape[0]
         else:
@@ -141,10 +139,8 @@ class BaseDataset:
 
     @staticmethod
     def get_sample(batch, key, index, conv_type):
-        
         assert hasattr(batch, key)
         is_dense = ConvolutionFormatFactory.check_is_dense_format(conv_type)
-
         if is_dense:
             return batch[key][index]
         else:
@@ -173,17 +169,12 @@ class BaseDataset:
             )
 
         if self.test_dataset:
-            if not isinstance(self.test_dataset, list):
-                test_dataset = [self.test_dataset]
-            else:
-                test_dataset = self.test_dataset
             self._test_loaders = [
                 dataloader(
                     dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers, sampler=self.test_sampler,
                 )
-                for dataset in test_dataset
+                for dataset in self.test_dataset
             ]
-            self._test_dataset_names = [self.get_test_dataset_name(idx) for idx in range(self.num_test_datasets)]
 
         if self.val_dataset:
             self._val_loader = dataloader(
@@ -205,25 +196,76 @@ class BaseDataset:
         except:
             False
 
+    @property
+    def train_dataset(self):
+        return self._train_dataset
+
+    @train_dataset.setter
+    def train_dataset(self, value):
+        self._train_dataset = value
+        if not hasattr(self._train_dataset, "name"):
+            setattr(self._train_dataset, "name", "train")
+
+    @property
+    def val_dataset(self):
+        return self._val_dataset
+
+    @val_dataset.setter
+    def val_dataset(self, value):
+        self._val_dataset = value
+        if not hasattr(self._val_dataset, "name"):
+            setattr(self._val_dataset, "name", "val")
+
+    @property
+    def test_dataset(self):
+        return self._test_dataset
+
+    @test_dataset.setter
+    def test_dataset(self, value):
+        if isinstance(value, list):
+            self._test_dataset = value
+        else:
+            self._test_dataset = [value]
+
+        for i, dataset in enumerate(self._test_dataset):
+            if not hasattr(dataset, "name"):
+                if self.num_test_datasets > 1:
+                    setattr(dataset, "name", "test_%i" % i)
+                else:
+                    setattr(dataset, "name", "test")
+            else:
+                self._contains_dataset_name = True
+
+        # Check for uniqueness
+        all_names = [d.name for d in self.test_dataset]
+        if len(set(all_names)) != len(all_names):
+            raise ValueError("Datasets need to have unique names. Current names are {}".format(all_names))
+
+    @property
+    def train_dataloader(self):
+        return self._train_loader
+
+    @property
     def val_dataloader(self):
         return self._val_loader
 
+    @property
     def test_dataloaders(self):
         return self._test_loaders
 
     @property
     def num_test_datasets(self):
-        return len(self._test_loaders)
+        return len(self._test_dataset)
 
     @property
     def test_datatset_names(self):
-        return self._test_dataset_names
+        return [d.name for d in self.test_dataset]
 
     @property
     def available_stage_names(self):
-        out = self._test_dataset_names
+        out = self.test_datatset_names
         if self.has_val_loader:
-            out += ["val"]
+            out += [self._val_dataset.name]
         return out
 
     @property
@@ -253,9 +295,6 @@ class BaseDataset:
             if isinstance(transform, FixedPoints):
                 test_bool = True
         return train_bool and test_bool
-
-    def train_dataloader(self):
-        return self._train_loader
 
     @property
     def is_hierarchical(self):
@@ -299,27 +338,29 @@ class BaseDataset:
     def batch_size(self):
         return self._batch_size
 
-    def get_test_dataset_name(self, index=None):
-        loader = self._test_loaders[index]
-        if hasattr(loader.dataset, "dataset_name"):
-            self._contains_dataset_name = True
-            return loader.dataset.dataset_name
-        else:
-            if self.num_test_datasets > 1:
-                return "test_{}".format(index)
-            else:
-                return "test"
-
     @property
     def num_batches(self):
         out = {
-            "train": len(self._train_loader),
+            self.train_dataset.name: len(self._train_loader),
             "val": len(self._val_loader) if self.has_val_loader else 0,
         }
-        for loader_idx, loader in enumerate(self._test_loaders):
-            stage_name = self.get_test_dataset_name(loader_idx)
+        for loader in self._test_loaders:
+            stage_name = loader.dataset.name
             out[stage_name] = len(loader)
         return out
+
+    def get_dataset(self, name):
+        """ Get a dataset by name. Raises an exception if no dataset was found
+        
+        Parameters
+        ----------
+        name : str
+        """
+        all_datasets = [self.train_dataset, self.val_dataset] + [t for t in self.test_dataset]
+        for dataset in all_datasets:
+            if dataset.name == name:
+                return dataset
+        raise ValueError("No dataset with name %s was found." % name)
 
     def _set_composed_multiscale_transform(self, attr, transform):
         current_transform = getattr(attr.dataset, "transform", None)
@@ -363,15 +404,15 @@ class BaseDataset:
 
         if self.num_test_datasets > 1 and not self._contains_dataset_name:
             msg = "If you want to have better trackable names for your test datasets, add a "
-            msg += COLORS.IPurple + "dataset_name" + COLORS.END_NO_TOKEN
+            msg += COLORS.IPurple + "name" + COLORS.END_NO_TOKEN
             msg += " attribute to them"
             log.info(msg)
 
         if selection_stage == "":
             if self.has_val_loader:
-                selection_stage = "val"
+                selection_stage = self.val_dataset.name
             else:
-                selection_stage = self.get_test_dataset_name(0)
+                selection_stage = self.test_dataset[0].name
         log.info(
             "The models will be selected using the metrics on following dataset: {} {} {}".format(
                 COLORS.IPurple, selection_stage, COLORS.END_NO_TOKEN
@@ -396,6 +437,8 @@ class BaseDataset:
                     size = len(dataset)
                 else:
                     size = 0
+                if attr.startswith("_"):
+                    attr = attr[1:]
                 message += "Size of {}{} {}= {}\n".format(COLORS.IPurple, attr, COLORS.END_NO_TOKEN, size)
         for key, attr in self.__dict__.items():
             if key.endswith("_sampler") and attr:

--- a/src/datasets/segmentation/forward/shapenet.py
+++ b/src/datasets/segmentation/forward/shapenet.py
@@ -147,12 +147,12 @@ class ForwardShapenetDataset(BaseDataset):
         setattr(batch, "_pred", output)
         for b in range(num_sample):
             sampleid = batch.sampleid[b]
-            sample_raw_pos = self.test_dataset.get_raw(sampleid).pos.to(output.device)
+            sample_raw_pos = self.test_dataset[0].get_raw(sampleid).pos.to(output.device)
             predicted = BaseDataset.get_sample(batch, "_pred", b, conv_type)
             origindid = BaseDataset.get_sample(batch, SaveOriginalPosId.KEY, b, conv_type)
             full_prediction = knn_interpolate(predicted, sample_raw_pos[origindid], sample_raw_pos, k=3)
             labels = full_prediction.max(1)[1].unsqueeze(-1)
-            full_res_results[self.test_dataset.get_filename(sampleid)] = np.hstack(
+            full_res_results[self.test_dataset[0].get_filename(sampleid)] = np.hstack(
                 (sample_raw_pos.cpu().numpy(), labels.cpu().numpy(),)
             )
         return full_res_results

--- a/test/test_basedataset.py
+++ b/test/test_basedataset.py
@@ -131,7 +131,7 @@ class TestDataset(unittest.TestCase):
         model = MockModel(model_config)
         dataset.create_dataloaders(model, 5, True, 0, False)
 
-        loaders = dataset.test_dataloaders()
+        loaders = dataset.test_dataloaders
         self.assertEqual(len(loaders), 2)
         self.assertEqual(len(loaders[0].dataset), 10)
         self.assertEqual(len(loaders[1].dataset), 20)
@@ -166,9 +166,31 @@ class TestDataset(unittest.TestCase):
         model = MockModel(model_config)
 
         mock_base_dataset.create_dataloaders(model, 2, True, 0, False)
-        datasets = mock_base_dataset.test_dataloaders()
+        datasets = mock_base_dataset.test_dataloaders
 
         self.assertEqual(len(datasets), 1)
+
+    def test_get_by_name(self):
+        dataset_opt = MockDatasetConfig()
+        setattr(dataset_opt, "dataroot", os.path.join(DIR, "temp_dataset"))
+
+        mock_base_dataset = MockBaseDataset(dataset_opt)
+        mock_base_dataset.test_dataset = [MockDataset(), MockDataset()]
+        mock_base_dataset.train_dataset = MockDataset()
+        mock_base_dataset.val_dataset = MockDataset()
+
+        for name in ["train", "val", "test_0", "test_1"]:
+            self.assertEqual(mock_base_dataset.get_dataset(name).name, name)
+
+        test_with_name = MockDataset()
+        setattr(test_with_name, "name", "testos")
+        mock_base_dataset.test_dataset = test_with_name
+        with self.assertRaises(ValueError):
+            mock_base_dataset.get_dataset("test_1")
+        mock_base_dataset.get_dataset("testos")
+
+        with self.assertRaises(ValueError):
+            mock_base_dataset.test_dataset = [test_with_name,test_with_name]
 
 
 class TestBatchCollate(unittest.TestCase):

--- a/test/test_shapenetforward.py
+++ b/test/test_shapenetforward.py
@@ -45,14 +45,14 @@ class TestForwardData(unittest.TestCase):
     def test_dataloaders(self):
         dataset = ForwardShapenetDataset(self.config)
         dataset.create_dataloaders(MockModel(DictConfig({"conv_type": "DENSE"})), 2, False, 1, False)
-        forward_set = dataset.test_dataloaders()[0]
+        forward_set = dataset.test_dataloaders[0]
         for b in forward_set:
             self.assertEqual(b.origin_id.shape, (2, 2))
 
         sparseconfig = DictConfig({"dataroot": self.datadir, "category": "Airplane", "forward_category": "Airplane"})
         dataset = ForwardShapenetDataset(sparseconfig)
         dataset.create_dataloaders(MockModel(DictConfig({"conv_type": "PARTIAL_DENSE"})), 2, False, 1, False)
-        forward_set = dataset.test_dataloaders()[0]
+        forward_set = dataset.test_dataloaders[0]
         for b in forward_set:
             torch.testing.assert_allclose(b.origin_id, torch.tensor([0, 1, 2, 0, 1, 2, 3]))
             torch.testing.assert_allclose(b.sampleid, torch.tensor([0, 1]))
@@ -60,7 +60,7 @@ class TestForwardData(unittest.TestCase):
     def test_predictupsampledense(self):
         dataset = ForwardShapenetDataset(self.config)
         dataset.create_dataloaders(MockModel(DictConfig({"conv_type": "DENSE"})), 2, False, 1, False)
-        forward_set = dataset.test_dataloaders()[0]
+        forward_set = dataset.test_dataloaders[0]
         for b in forward_set:
             output = torch.tensor([[1, 0], [1, 0], [0, 1], [0, 1]])
             predicted = dataset.predict_original_samples(b, "DENSE", output)
@@ -73,7 +73,7 @@ class TestForwardData(unittest.TestCase):
     def test_predictupsamplepartialdense(self):
         dataset = ForwardShapenetDataset(self.config)
         dataset.create_dataloaders(MockModel(DictConfig({"conv_type": "PARTIAL_DENSE"})), 2, False, 1, False)
-        forward_set = dataset.test_dataloaders()[0]
+        forward_set = dataset.test_dataloaders[0]
         for b in forward_set:
             output = torch.tensor([[1, 0], [1, 0], [0, 1], [0, 1]])
             predicted = dataset.predict_original_samples(b, "PARTIAL_DENSE", output)

--- a/train.py
+++ b/train.py
@@ -39,7 +39,7 @@ def train_epoch(
     model.train()
     tracker.reset("train")
     visualizer.reset(epoch, "train")
-    train_loader = dataset.train_dataloader()
+    train_loader = dataset.train_dataloader
 
     iter_data_time = time.time()
     with Ctq(train_loader) as tq_train_loader:
@@ -85,7 +85,7 @@ def eval_epoch(
     model.eval()
     tracker.reset("val")
     visualizer.reset(epoch, "val")
-    loader = dataset.val_dataloader()
+    loader = dataset.val_dataloader
     with Ctq(loader) as tq_val_loader:
         for data in tq_val_loader:
             with torch.no_grad():
@@ -118,10 +118,10 @@ def test_epoch(
 ):
     model.eval()
 
-    loaders = dataset.test_dataloaders()
+    loaders = dataset.test_dataloaders
 
-    for idx, loader in enumerate(loaders):
-        stage_name = dataset.get_test_dataset_name(idx)
+    for loader in loaders:
+        stage_name = loader.dataset.name
         tracker.reset(stage_name)
         visualizer.reset(epoch, stage_name)
         with Ctq(loader) as tq_test_loader:


### PR DESCRIPTION
This PR forces all datasets to have a `name` property. A sub dataset can now we grabbed by name. The aim is to use that to track the provenance or a data object that was produced by one of the data loaders for example. It also clarifies some of the existing features around dataset names.